### PR TITLE
Fix/stats

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,16 +23,16 @@ module.exports = (compiler, opts) => {
 
   const compile = (comp) => {
     const compilerName = comp.name || '<unnamed compiler>';
-    options.stats = null;
+    options.lastJsonStats = null;
     log.info('webpack: Compiling...');
     server.broadcast(payload('compile', { compilerName }));
   };
 
-  const done = (result) => {
+  const done = (stats) => {
     log.info('webpack: Compiling Done');
-    options.stats = result;
 
-    const jsonStats = options.stats.toJson(options.stats);
+    const jsonStats = stats.toJson(options.stats);
+    options.lastJsonStats = jsonStats;
 
     /* istanbul ignore if */
     if (!jsonStats) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -26,6 +26,9 @@ const defaults = {
   server: null,
   stats: {
     context: process.cwd(),
+    assets: true,
+    modules: false,
+    chunks: false,
   },
   validTargets: ['web'],
   test: false,

--- a/lib/socket-server.js
+++ b/lib/socket-server.js
@@ -69,7 +69,7 @@ function onConnection(server, options) {
     // only send stats to newly connected clients, if no previous clients have
     // connected and stats has been modified by webpack
     if (options.lastJsonStats && server.clients.size === 1) {
-      server.send(jsonStats);
+      server.send(options.lastJsonStats);
     }
   });
 }

--- a/lib/socket-server.js
+++ b/lib/socket-server.js
@@ -68,14 +68,7 @@ function onConnection(server, options) {
 
     // only send stats to newly connected clients, if no previous clients have
     // connected and stats has been modified by webpack
-    if (options.stats && options.stats.toJson && server.clients.size === 1) {
-      const jsonStats = options.stats.toJson(options.stats);
-
-      /* istanbul ignore if */
-      if (!jsonStats) {
-        options.log.error('Client Connection: `stats` is undefined');
-      }
-
+    if (options.lastJsonStats && server.clients.size === 1) {
       server.send(jsonStats);
     }
   });

--- a/test/socket-server.test.js
+++ b/test/socket-server.test.js
@@ -91,13 +91,12 @@ describe('socket server', () => {
   });
 
   test('send via stats', (done) => {
-    const stats = {
-      context: process.cwd(),
-      toJson: () => {
-        return { hash: '111111', warnings: [] };
-      },
+    const lastJsonStats = {
+      hash: '111111',
+      warnings: [],
     };
-    const opts = getOptions({ logLevel: 'silent', stats });
+    const opts = getOptions({ logLevel: 'silent' });
+    opts.lastJsonStats = lastJsonStats;
     const server = getServer(opts);
     const { close } = server;
 


### PR DESCRIPTION
This includes
- Fix to avoid ignoring options.stats (from https://github.com/webpack-contrib/webpack-hot-client/pull/97)
- Default stats options which increase performance by not outputting unused information about modules and chunks